### PR TITLE
Create run and install scripts

### DIFF
--- a/backend/src/fillGames.js
+++ b/backend/src/fillGames.js
@@ -66,17 +66,23 @@ async function addGameToDatabase(game) {
   }
 }
 
-async function processGames() {
-    const startId = 1; // Start ID
-    const endId = 1000; // End ID; Amount of games you want to process
+async function processGames(endId) {
+  const startId = 1;
 
-    for (let id = startId; id <= endId; id++) {
-        const gameData = await fetchGameFromBGG(id);
-        if (gameData) {
-            const transformedGame = transformGameData(gameData);
-            await addGameToDatabase(transformedGame);
-        }
+  for (let id = startId; id <= endId; id++) {
+    const gameData = await fetchGameFromBGG(id);
+    if (gameData) {
+        const transformedGame = transformGameData(gameData);
+        await addGameToDatabase(transformedGame);
     }
+  }
 }
 
-processGames();
+const numberOfGames = parseInt(process.argv[2], 10);
+
+if (isNaN(numberOfGames) || numberOfGames <= 0) {
+    console.error('Please provide a valid number of games to process.');
+    process.exit(1);
+}
+
+processGames(numberOfGames);

--- a/install-with-users.js
+++ b/install-with-users.js
@@ -23,7 +23,12 @@ const main = async () => {
     await runCommand('npm', ['install'], './backend');
 
     await runCommand('node', ['createTables.js'], './backend/src');
-    await runCommand('node', ['fillGames.js'], './backend/src');
+    const numberOfGames = process.argv[2];
+    if (!numberOfGames || isNaN(numberOfGames)) {
+      throw new Error("Please provide a valid number of games as a command line argument.");
+    }
+
+    await runCommand('node', ['fillGames.js', numberOfGames], './backend/src');
     await runCommand('node', ['fillUsers.js'], './backend/src');
 
     console.log('All tasks completed successfully');

--- a/install-with-users.js
+++ b/install-with-users.js
@@ -24,6 +24,7 @@ const main = async () => {
 
     await runCommand('node', ['createTables.js'], './backend/src');
     await runCommand('node', ['fillGames.js'], './backend/src');
+    await runCommand('node', ['fillUsers.js'], './backend/src');
 
     console.log('All tasks completed successfully');
   } catch (err) {

--- a/install.js
+++ b/install.js
@@ -1,0 +1,36 @@
+const { spawn } = require('child_process');
+const path = require('path');
+
+const runCommand = (command, args, directory) => {
+  return new Promise((resolve, reject) => {
+    const fullDirectory = path.join(__dirname, directory);
+    const spawned = spawn(command, args, { cwd: fullDirectory, stdio: 'inherit', shell: true });
+
+    spawned.on('error', reject);
+    spawned.on('close', (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(`"${command}" process exited with code ${code}`);
+      }
+    });
+  });
+};
+
+const main = async () => {
+  try {
+    // Install dependencies in frontend and backend
+    await runCommand('npm', ['install'], './frontend');
+    await runCommand('npm', ['install'], './backend');
+
+    // Run createTables.js and fillGames.js in the backend
+    await runCommand('node', ['createTables.js'], './backend/src');
+    await runCommand('node', ['fillGames.js'], './backend/src');
+
+    console.log('All tasks completed successfully');
+  } catch (err) {
+    console.error('An error occurred:', err);
+  }
+};
+
+main();

--- a/install.js
+++ b/install.js
@@ -23,7 +23,13 @@ const main = async () => {
     await runCommand('npm', ['install'], './backend');
 
     await runCommand('node', ['createTables.js'], './backend/src');
-    await runCommand('node', ['fillGames.js'], './backend/src');
+
+    const numberOfGames = process.argv[2];
+    if (!numberOfGames || isNaN(numberOfGames)) {
+      throw new Error("Please provide a valid number of games as a command line argument.");
+    }
+
+    await runCommand('node', ['fillGames.js', numberOfGames], './backend/src');
 
     console.log('All tasks completed successfully');
   } catch (err) {

--- a/run.js
+++ b/run.js
@@ -1,0 +1,16 @@
+const { spawn } = require('child_process');
+const path = require('path');
+
+const runCommand = (command, args, directory) => {
+  const fullDirectory = path.join(__dirname, directory);
+  const spawned = spawn(command, args, { cwd: fullDirectory, stdio: 'inherit', shell: true });
+
+  spawned.on('error', (err) => {
+    console.error(`Failed to start "${command}" in "${fullDirectory}": ${err}`);
+  });
+
+  return spawned;
+};
+
+runCommand('npm', ['run', 'serve'], './frontend');
+runCommand('npm', ['run', 'watch'], './backend');


### PR DESCRIPTION
## Related Issue
Last time when I opened a PR and needed to input all these commands, I got kinda irritated, so did this (and it will also be easier to write running instruction in documentation :P )

## Changes list
Changed createTables.js to take an argument from command line, to specify amount of games to process.
Created run script (runs both backend and frontend)
Created install script (runs npm installs, creates tables, and fills games)
Created install-with-users script, the same as install, but also runs fill users after fill games

## Testing instructions
Go to main dir
run node `backend/src/createTables.js 2`
check if script stops after 2 games (you can test with any other number)
run `node install.js 3`
check if everything was run correctly, and games adding stopped after 3 games
run `node install-with-users.js 5`
check if everything was run correctly, games stopped after adding 5 games, and if users were created
run `node run.js`
check if frontend and backend are running correctly

## Screenshots (if appropriate):
<!--- Only if something needs graphical explanation, or it will make the review easier -->
